### PR TITLE
docs: Correct test execution example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Run all flows defined in the folder .maestro/screenshot
 ```ruby
 maestro(
   command: 'test',
-  directory: '.maestro/screenshot',
+  tests: '.maestro/screenshot',
   report_type: 'junit'
 )
 ```


### PR DESCRIPTION
This PR corrects the `README` file as the path containing the Maestro test files is not called `directory` but `tests`.